### PR TITLE
fix: add tar to opkg install command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,7 +516,7 @@ opkg upgrade
 > Выполнять от пользователя root
 
 ```bash
-opkg install curl
+opkg install curl tar
 ```
 
 ```bash


### PR DESCRIPTION
Отсутствует tar пакет в скрипте установки, без него команда --overwrite из https://raw.githubusercontent.com/Skrill0/XKeen/main/install.sh очевидно падает