### PR TITLE
Автоматическая подготовка USB-накопителя для macOS (SWAP + EXT4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,40 @@ https://support.keenetic.ru/eaeu/ultra/kn-1811/ru/20978-preparing-a-usb-drive-as
 <details>
 <summary>Как отформатировать USB накопитель под macOS</summary>
 
+### Автоматическая подготовка (SWAP + EXT4) одной командой
+
+Для пользователей macOS доступен инструмент **[Keenetic Entware Flash](https://github.com/MaxXxaM/keenetic-entware-flash)**, который автоматически создаёт правильную разметку USB-накопителя: **SWAP-раздел** + **EXT4** с установщиком Entware — одной командой.
+
+Работает через Docker или нативно на macOS:
+
+**С Docker:**
+```bash
+git clone https://github.com/MaxXxaM/keenetic-entware-flash.git
+cd keenetic-entware-flash
+sudo ./run.sh
+```
+
+**Без Docker (нативно):**
+```bash
+brew install e2fsprogs
+diskutil list external physical
+
+# Замените disk4 на ваш диск
+sudo diskutil partitionDisk /dev/disk4 MBRFormat \
+  "MS-DOS FAT32" "SWAP" 1024M \
+  "MS-DOS FAT32" "OPKG" R
+
+diskutil unmountDisk /dev/disk4
+sudo $(brew --prefix e2fsprogs)/sbin/mkfs.ext4 -O ^metadata_csum -L OPKG -F /dev/disk4s2
+diskutil eject /dev/disk4
+```
+
+> SWAP-раздел будет автоматически инициализирован роутером. Entware скачается при включении компонента OPKG.
+
+---
+
+### Ручная подготовка (только EXT4, без SWAP)
+
 **1) Установка Homebrew**
 
 >*Если менеджер пакетов установлен, можете пропустить этот пункт и перейти к следующему.*


### PR DESCRIPTION
## Summary

Добавлено упоминание инструмента **[Keenetic Entware Flash](https://github.com/MaxXxaM/keenetic-entware-flash)** в секцию подготовки USB-накопителя для macOS.

## Проблема

Текущая инструкция для macOS описывает только форматирование флешки в EXT4 без создания SWAP-раздела. При этом в основной инструкции рекомендуется создавать SWAP первым разделом (512 МБ — 1 ГБ), но для macOS-пользователей не показано как это сделать.

## Решение

В раскрывающуюся секцию «Как отформатировать USB накопитель под macOS» добавлен блок **«Автоматическая подготовка (SWAP + EXT4) одной командой»** с двумя вариантами:

- **С Docker** — `git clone` + `sudo ./run.sh` (автоматический выбор флешки, разметка, форматирование, установщик Entware)
- **Без Docker (нативно)** — `diskutil partitionDisk` + `mkfs.ext4` через Homebrew

Существующая ручная инструкция сохранена как альтернативный вариант с пометкой «Ручная подготовка (только EXT4, без SWAP)».

🤖 Generated with [Claude Code](https://claude.com/claude-code)